### PR TITLE
172562818-bg(redirect): Redirect reset password link to UI

### DIFF
--- a/src/modules/email.js
+++ b/src/modules/email.js
@@ -13,15 +13,8 @@ const template = new mailgen({
 });
 
 sgMail.setApiKey(process.env.BN_API_KEY);
-let host;
-if (process.env.NODE_ENV === 'development') {
-  host = process.env.LOCAL_HOST;
-} else {
-  host = process.env.HOST_NAME;
-}
-
-export const getPasswordResetURL = (user, token) => `${host}/api/v1/password/reset/${user.id}/${token}`;
-
+let host=process.env.UI_URL;
+export const getPasswordResetURL = (user, token) => `${host}/password/reset/${user.id}/${token}`;
 const generateEmail = (name, instructions, buttonTxt, link) => ({
   body: {
     name,


### PR DESCRIPTION
#### What does this PR do?
- change rest password link from back end URL to UI URL
#### Description of Task to be completed?
- the link contained in a reset password email will redirect a user to the UI from
#### How should this be manually tested?
- open a terminal and run this command to clone project `https://github.com/Stackup-Rwanda/knights-bn-backend.git`
- run `git fetch && git checkout bg-change-reset-password-link-172562818`
- open you postman and use this link to reset password `https://knights-bn-backnd.herokuapp.com/api/v1/reset_pw/user` by sending a POST request with your email as a body request like this `{
"email":"eukigali@gmail.com"
}`
- if you don't have an account you can create it and reset password afterward.
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#172562818](https://www.pivotaltracker.com/story/show/172562818)
#### Screenshots (if appropriate)
N/A
#### Questions:
