### PR TITLE
#172842025: Add Users list in the response of updateRole endpoint

### DIFF
--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -180,7 +180,10 @@ export default class usersController {
       const existingUser = await userQuery.getUserByEmail(email);
       if (!existingUser) return res.status(404).json({ status: 404, error: `User  ${email} is not found!` });
       await userQuery.updateUserRole(role, email);
-      return res.status(200).json({ status: 200, message: 'User successfully updated!' });
+      const Users = await models.User.findAll({
+        attributes: ['id', 'email', 'firstName', 'lastName', 'gender', 'email', 'passport', 'method', 'lineManager', 'birthDay', 'language', 'role', 'department', 'profileImage'],
+      });
+      return res.status(200).json({ status: 200, message: 'User successfully updated!', Users });
     } catch (error) {
       return res.status(500).json({ error: error.message });
     }

--- a/src/middlewares/validateRole.js
+++ b/src/middlewares/validateRole.js
@@ -11,6 +11,7 @@ export default async (req, res, next) => {
           'travelTeamMember',
           'manager',
           'requester',
+          'supplier',
         ),
     }).messages({
       'string.base': 'Role should be a type of text',

--- a/src/tests/userRoles.test.js
+++ b/src/tests/userRoles.test.js
@@ -5,6 +5,12 @@ import mockData from './mockData';
 
 chai.use(chaiHttp);
 chai.should();
+
+const superAdminInfo = {
+  email: 'superadmin@barefootnomad.com',
+  password: 'Niyonkuru@1',
+};
+
 const testUserRoles = () => {
   describe('USER ROLE SETTINGS | FAULTY REQUESTS', () => {
     it('should sign in the a normal user', (done) => {
@@ -53,7 +59,17 @@ const testUserRoles = () => {
             });
         });
     });
-
+    it('should return 200 for successful signIn', (done) => {
+      chai
+        .request(app)
+        .post('/api/v1/auth/login')
+        .send(superAdminInfo)
+        .end((err, res) => {
+          expect(res.statusCode).to.equal(200);
+          expect(res.body).to.have.property('token');
+          done();
+        });
+    });
     it('should throw 404 if email is wrong', (done) => {
       chai
         .request(app)


### PR DESCRIPTION
#### What does this PR do?

- This will Add Users list in the response of updateRole endpoint

#### Description of Task to be completed?

- [x]  Added Users list the response body of update Role


#### How should this be manually tested?

- Clone the project

       https://github.com/Stackup-Rwanda/knights-bn-backend.git

- Move to the branch

       git checkout ch-fix-roleUpdate-response-172842025


- Install all the dependencies and start the server

       npm i && npm run dev-start

-  Use the following credentials to log in as an admin

       email: superadmin@barefootnomad.com

       password: Niyonkuru@1

- Use the following endpoint and Body


       URL:

       PATCH       
        http://localhost:4000/api/v1/users/setUserRole?email=alain.maxime@gmail.com

        Body:
        {  "role": "manager" } 

#### Any background context you want to provide?

- N/A

#### What are the relevant pivotal tracker stories?

- [#172842025](https://www.pivotaltracker.com/story/show/172842025)

#### Screenshots (if appropriate)

- `super-admin` log in

 
<img width="1136" alt="Screen Shot 2020-05-09 at 12 25 11" src="https://user-images.githubusercontent.com/48021034/81471290-5b68e100-91f0-11ea-9709-ee50203d2b77.png">


- Update Role(With the Users inside)


<img width="1169" alt="Screen Shot 2020-05-14 at 17 08 27" src="https://user-images.githubusercontent.com/48021034/81951537-8fd00900-9605-11ea-9c90-a8e3e844699d.png">

#### Questions:

- N/A